### PR TITLE
fix compile error in openwrt (LEDE) SDK

### DIFF
--- a/dns.h
+++ b/dns.h
@@ -66,7 +66,7 @@ typedef struct dns_header_t {
     unsigned ad: 1;
     unsigned cd: 1;
     unsigned rcode: 4;  /* response code */
-#endif
+#else
 #if BYTE_ORDER == LITTLE_ENDIAN || BYTE_ORDER == PDP_ENDIAN
     // Byte 3
     unsigned rd: 1;     /* recursion desired */
@@ -80,6 +80,7 @@ typedef struct dns_header_t {
     unsigned ad: 1;
     unsigned z: 1;      /* reserved */
     unsigned ra: 1;     /* recursion available */
+#endif
 #endif
     uint16_t qdcount;
     uint16_t ancount;


### PR DESCRIPTION
I guess, the compiler wont know they are exclusive conditions.